### PR TITLE
fix(mobile/ios-build): add Babel config and preset for Xcode bundling

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,7 +1,11 @@
-/** @type {import('@babel/core').TransformOptions} */
 module.exports = function (api) {
   api.cache(true)
   return {
-    presets: ["babel-preset-expo"],
+    presets: ['babel-preset-expo'],
+    plugins: [
+      // Keep this last per Reanimated docs
+      'react-native-reanimated/plugin',
+    ],
   }
 }
+

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -72,6 +72,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
+    "babel-preset-expo": "~13.2.4",
     "@testing-library/react-native": "^13.2.0",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.0.10",


### PR DESCRIPTION
Fixes CI beta build failure due to missing Babel preset during Xcode bundling.\n\nError in logs (mobile-mobile.log):\n- Cannot find module 'babel-preset-expo'\n\nChanges:\n- Add apps/mobile/babel.config.js with presets ['babel-preset-expo'] and reanimated plugin.\n- Add devDependency 'babel-preset-expo' to apps/mobile/package.json.\n\nThis should allow Metro bundling inside Xcode to resolve the Expo preset.\n\nTarget: develop