### PR TITLE
fix(ci/fastlane): use @api_key for ASC auth in deploy lanes

### DIFF
--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -26,7 +26,8 @@ before_all do |lane|
   end
 
   if api_hash
-    api_key = app_store_connect_api_key(
+    # Store as instance variable so it's available in lanes
+    @api_key = app_store_connect_api_key(
       key_id: api_hash["key_id"],
       issuer_id: api_hash["issuer_id"],
       key_content: api_hash["key"],
@@ -92,7 +93,7 @@ platform :ios do
     
     # Build the app for development
     gym(
-      api_key: api_key,
+      api_key: @api_key,
       scheme: "mobile",
       configuration: "Debug",
       export_method: "development",
@@ -111,7 +112,7 @@ platform :ios do
     
     # Build the app
     gym(
-      api_key: api_key,
+      api_key: @api_key,
       scheme: "mobile",
       configuration: "Release",
       export_method: "ad-hoc",
@@ -169,7 +170,7 @@ platform :ios do
     # Ensure Export Compliance metadata is set (encryption)
     # This updates the current version's submission information without uploading metadata/screenshots
     deliver(
-      api_key: api_key,
+      api_key: @api_key,
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: true,
@@ -230,7 +231,7 @@ platform :ios do
     
     # Upload to App Store Connect
     deliver(
-      api_key: api_key,
+      api_key: @api_key,
       ipa: "./builds/production/SalespersonTracker-Production.ipa",
       submit_for_review: false, # Manual review submission
       automatic_release: false,


### PR DESCRIPTION
Fix beta pipeline failure after archive by ensuring Fastlane lanes use an App Store Connect API key in scope.\n\nChanges:\n- Define API key as instance variable in before_all.\n- Pass  to deliver/gym calls.\n\nContext:\n- Xcode archive succeeds (see mobile-mobile.log), likely failure during deliver/pilot due to undefined local variable .\n\nTarget: develop