### PR TITLE
fix(ci/fastlane): pass @api_key to pilot upload in deploy_beta

### DIFF
--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -190,6 +190,7 @@ platform :ios do
 
     # Upload to TestFlight
     pilot(
+      api_key: @api_key,
       ipa: "./builds/production/SalespersonTracker-Production.ipa",
       changelog: changelog,
       distribute_external: false, # Only internal testers initially


### PR DESCRIPTION
Follow-up to CI Fastlane auth fixes. Ensures TestFlight upload (pilot) uses the App Store Connect API key by passing  in deploy_beta.\n\n- File: apps/mobile/ios/fastlane/Fastfile\n- Scope: CI beta pipeline after successful archive\n\nTarget: develop