### PR TITLE
ci(beta): upload Fastlane logs on failure

### DIFF
--- a/.github/workflows/mobile-beta.yml
+++ b/.github/workflows/mobile-beta.yml
@@ -82,3 +82,4 @@ jobs:
           path: |
             ~/Library/Logs/gym/**/*
             ~/Library/Logs/scan/**/*
+            ~/Library/Logs/fastlane/**/*


### PR DESCRIPTION
Adds Fastlane logs to the failure artifacts for the TestFlight beta workflow, alongside existing Xcode/Gym logs.\n\n- Workflow: .github/workflows/mobile-beta.yml\n- Artifact now includes: \n  - ~/Library/Logs/gym/**/*\n  - ~/Library/Logs/scan/**/*\n  - ~/Library/Logs/fastlane/**/*\n\nThis will make diagnosing post-archive deliver/pilot issues much easier.