### PR TITLE
fix(ci/deliver): remove app_rating_config_path for skip_metadata runs

### DIFF
--- a/apps/mobile/ios/fastlane/Deliverfile
+++ b/apps/mobile/ios/fastlane/Deliverfile
@@ -44,8 +44,8 @@ copyright "© 2024 Harebrained Apps. All rights reserved."
 primary_category "BUSINESS"
 secondary_category "PRODUCTIVITY"
 
-# Age rating - Business app with location tracking
-app_rating_config_path "./metadata/app_rating_config.json"
+# Age rating config removed for CI deliver with skip_metadata
+# If needed later, re-add with a valid path and file.
 
 # Release notes directory
 release_notes({


### PR DESCRIPTION
Fixes beta pipeline error: Could not find config file at path 'apps/mobile/ios/metadata/app_rating_config.json'.\n\nSince we call deliver with , we remove  from Deliverfile to avoid deliver trying to load a non-existent file.\n\n- File: apps/mobile/ios/fastlane/Deliverfile\n- Change: remove app_rating_config_path line\n\nTarget: develop