### PR TITLE
fix(ci/deliver): disable IAP precheck with API key auth

### DIFF
--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -174,6 +174,9 @@ platform :ios do
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: true,
+      # Precheck cannot verify IAPs with API key auth; disable that check
+      precheck_include_in_app_purchases: false,
+      run_precheck_before_submit: false,
       submit_for_review: false,
       force: true,
       submission_information: {
@@ -233,6 +236,8 @@ platform :ios do
     # Upload to App Store Connect
     deliver(
       api_key: @api_key,
+      precheck_include_in_app_purchases: false,
+      run_precheck_before_submit: false,
       ipa: "./builds/production/SalespersonTracker-Production.ipa",
       submit_for_review: false, # Manual review submission
       automatic_release: false,


### PR DESCRIPTION
Precheck cannot verify In‑App Purchases when authenticating with an App Store Connect API key.\n\nFix in both deliver calls:\n- precheck_include_in_app_purchases: false\n- run_precheck_before_submit: false\n\nThis unblocks the beta pipeline where deliver is used for export‑compliance metadata and production upload.\n\nFile: apps/mobile/ios/fastlane/Fastfile\nTarget: develop