### PR TITLE
ci: fix GitHub Actions conditionals for Sentry steps

### DIFF
--- a/.github/workflows/mobile-beta.yml
+++ b/.github/workflows/mobile-beta.yml
@@ -13,6 +13,11 @@ jobs:
     name: Build and Upload to TestFlight
     runs-on: macos-latest
     timeout-minutes: 60
+    env:
+      # Expose Sentry values as env so we can branch on env.* in step if:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,16 +81,12 @@ jobs:
 
       # Optional: Upload dSYMs to Sentry for better native stack traces
       - name: Install Sentry CLI (optional)
-        if: ${{ success() && secrets.SENTRY_AUTH_TOKEN != '' }}
+        if: ${{ success() && env.SENTRY_AUTH_TOKEN != '' }}
         run: |
           curl -sL https://sentry.io/get-cli/ | bash
 
       - name: Upload dSYMs to Sentry (optional)
-        if: ${{ success() && secrets.SENTRY_AUTH_TOKEN != '' }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        if: ${{ success() && env.SENTRY_AUTH_TOKEN != '' }}
         run: |
           LATEST_ARCHIVE=$(ls -t ~/Library/Developer/Xcode/Archives/*/*.xcarchive | head -n1 || true)
           if [ -z "$LATEST_ARCHIVE" ]; then
@@ -97,12 +98,8 @@ jobs:
 
       # Optional: Upload JS source maps with sentry-expo
       - name: Upload JS sourcemaps to Sentry (optional)
-        if: ${{ success() && secrets.SENTRY_AUTH_TOKEN != '' }}
+        if: ${{ success() && env.SENTRY_AUTH_TOKEN != '' }}
         working-directory: apps/mobile
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: |
           BUNDLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" ios/mobile/Info.plist)
           VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" ios/mobile/Info.plist)

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 90
     environment: production
+    env:
+      # Expose Sentry values as env so we can branch on env.* in step if:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -77,16 +82,12 @@ jobs:
 
       # Optional: Upload dSYMs to Sentry for better native stack traces
       - name: Install Sentry CLI (optional)
-        if: ${{ success() && secrets.SENTRY_AUTH_TOKEN != '' }}
+        if: ${{ success() && env.SENTRY_AUTH_TOKEN != '' }}
         run: |
           curl -sL https://sentry.io/get-cli/ | bash
 
       - name: Upload dSYMs to Sentry (optional)
-        if: ${{ success() && secrets.SENTRY_AUTH_TOKEN != '' }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        if: ${{ success() && env.SENTRY_AUTH_TOKEN != '' }}
         run: |
           LATEST_ARCHIVE=$(ls -t ~/Library/Developer/Xcode/Archives/*/*.xcarchive | head -n1 || true)
           if [ -z "$LATEST_ARCHIVE" ]; then
@@ -98,12 +99,8 @@ jobs:
 
       # Optional: Upload JS source maps with sentry-expo
       - name: Upload JS sourcemaps to Sentry (optional)
-        if: ${{ success() && secrets.SENTRY_AUTH_TOKEN != '' }}
+        if: ${{ success() && env.SENTRY_AUTH_TOKEN != '' }}
         working-directory: apps/mobile
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: |
           BUNDLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" ios/mobile/Info.plist)
           VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" ios/mobile/Info.plist)


### PR DESCRIPTION
Fixes workflow syntax error by avoiding direct 'secrets' context in step-level if.\n\nChanges:\n- Map SENTRY_* secrets into job 'env' and reference them via 'env.SENTRY_AUTH_TOKEN' in step 'if:' expressions.\n- Updated both beta and release workflows.\n\nFiles:\n- .github/workflows/mobile-beta.yml\n- .github/workflows/mobile-release.yml\n\nResult:\n- Workflows validate and conditionally run Sentry upload steps when secrets are present.\n\nTarget: develop