### PR TITLE
feat(db): sessionized visit detection using account geofence radius

### DIFF
--- a/docs/visit-tracking-plan.md
+++ b/docs/visit-tracking-plan.md
@@ -1,0 +1,61 @@
+# Visit Tracking Improvement Plan
+
+This plan drives accuracy and reliability for visit detection while keeping device battery usage low and server logic auditable.
+
+## Phase 1 — Detection Engine (Now)
+
+- [ ] Apply migration 010_sessionized_visit_detection.sql in Supabase.
+  - Switch proximity to `a.geofence_radius + 50` meters.
+  - Sessionize per account: new session when gap > 60 minutes.
+  - Keep min dwell ≥ 10 minutes and ≥ 2 events.
+- [ ] Validate on recent data (7 days):
+  - Detector preview: `detect_visits_from_location_events(user, 24)`
+  - Long visits gone; durations realistic (10–120 min typical).
+  - Edge users/accounts spot-checked.
+
+## Phase 2 — Safeguards & Tunables
+
+- [ ] Add max visit duration cap (e.g., 8h) with auto-split.
+- [ ] Bound radius per account (e.g., min 50m, max 500m).
+- [ ] Make `gap_minutes`, `min_dwell`, and `buffer_meters` configurable.
+
+## Phase 3 — Overlap & Motion Awareness
+
+- [ ] Overlap resolution across nearby accounts:
+  - Choose account with lowest median distance and highest confidence.
+  - If ambiguous, flag for review.
+- [ ] Speed gating:
+  - Break or down-weight events when inferred speed > X km/h (transit).
+
+## Phase 4 — Client Refinements (Battery‑Safe)
+
+- [ ] High-accuracy burst when within ~2× geofence radius (once per 10–15 min/account).
+- [ ] Optional iOS region monitoring for small assigned sets (rotate nearest N).
+- [ ] Filter events with very poor accuracy (>150–200m) unless needed.
+
+## Phase 5 — Observability & Tooling
+
+- [ ] Persist audit fields on visits: detection version, event_count, median distance, avg accuracy, inside ratio, chosen thresholds.
+- [ ] Add `detection_explanations` JSONB for debugging decisions.
+- [ ] Admin inspector UI: plot session events, distances, reasons accepted/rejected, re-run tools.
+
+## Phase 6 — Metrics & Operations
+
+- [ ] Cron idempotency + reprocess window (last 7–14 days) by detection version.
+- [ ] Dashboards: visits/user/day, duration distribution, overlap rate, capped/split rate.
+- [ ] Alerts for anomalies (e.g., many visits > 8h, sudden drop in visits).
+
+## Phase 7 — Pilot & Tuning
+
+- [ ] Pilot with subset of users; collect feedback.
+- [ ] Tune `gap_minutes`, `min_dwell`, buffer, speed thresholds.
+- [ ] Success criteria: 
+  - Eliminate all‑day 20h visits (unless legitimate).
+  - ≥90% visits match ground truth within 10–15 minutes.
+  - Overlap false positives reduced by >50%.
+
+## Notes
+
+- Keep SLC as primary signal for battery life; server does the heavy lifting.
+- Consider polygon geofences for complex sites in later iterations.
+

--- a/supabase/migrations/010_sessionized_visit_detection.sql
+++ b/supabase/migrations/010_sessionized_visit_detection.sql
@@ -1,0 +1,119 @@
+-- Update visit detection to use per-account geofence radii and
+-- split visits into sessions based on time gaps between events.
+
+-- This replaces the proximity filter (previously fixed ~1000m)
+-- with `a.geofence_radius + margin_meters`, and introduces a
+-- session index that starts a new session when the gap between
+-- consecutive events for the same account exceeds `gap_minutes`.
+
+CREATE OR REPLACE FUNCTION detect_visits_from_location_events(
+    target_user_id UUID,
+    time_window_hours INTEGER DEFAULT 24
+)
+RETURNS TABLE (
+    account_id UUID,
+    account_name TEXT,
+    entry_time TIMESTAMPTZ,
+    exit_time TIMESTAMPTZ,
+    duration_minutes INTEGER,
+    confidence DECIMAL,
+    event_count INTEGER,
+    avg_accuracy DECIMAL,
+    location_events_ids UUID[]
+) AS $$
+DECLARE
+    min_dwell_minutes INTEGER := 10;   -- minimum dwell time to consider a visit
+    gap_minutes INTEGER := 60;         -- split sessions when gap between events exceeds this
+    margin_meters INTEGER := 50;       -- small buffer added to the geofence radius
+BEGIN
+    RETURN QUERY
+    WITH location_events_with_accounts AS (
+        SELECT 
+            le.id AS event_id,
+            le.user_id,
+            le.timestamp,
+            le.latitude,
+            le.longitude,
+            le.accuracy,
+            a.id AS account_id,
+            a.account_name,
+            a.geofence_radius,
+            ST_Distance(
+                ST_Point(le.longitude, le.latitude)::geography,
+                ST_Point(a.longitude, a.latitude)::geography
+            ) AS distance_meters
+        FROM location_events le
+        INNER JOIN user_accounts ua ON ua.user_id = le.user_id
+        INNER JOIN accounts a ON a.id = ua.account_id
+        WHERE le.user_id = target_user_id
+          AND le.timestamp >= NOW() - INTERVAL '1 hour' * time_window_hours
+          AND ua.is_active = true
+          AND a.is_active = true
+          AND ST_DWithin(
+                ST_Point(le.longitude, le.latitude)::geography,
+                ST_Point(a.longitude, a.latitude)::geography,
+                (a.geofence_radius + margin_meters)
+          )
+    ),
+    sequenced AS (
+        SELECT
+            lea.*,
+            CASE
+                WHEN LAG(lea.timestamp) OVER (PARTITION BY lea.account_id ORDER BY lea.timestamp) IS NULL THEN 0
+                WHEN EXTRACT(EPOCH FROM (
+                        lea.timestamp - LAG(lea.timestamp) OVER (PARTITION BY lea.account_id ORDER BY lea.timestamp)
+                    )) / 60 > gap_minutes THEN 1
+                ELSE 0
+            END AS is_break
+        FROM location_events_with_accounts lea
+    ),
+    sessioned AS (
+        SELECT
+            s.*,
+            SUM(is_break) OVER (
+                PARTITION BY s.account_id
+                ORDER BY s.timestamp
+                ROWS UNBOUNDED PRECEDING
+            ) AS session_index
+        FROM sequenced s
+    ),
+    visit_candidates AS (
+        SELECT 
+            account_id,
+            MIN(timestamp) AS entry_time,
+            MAX(timestamp) AS exit_time,
+            COUNT(*) AS event_count,
+            AVG(accuracy) AS avg_accuracy,
+            AVG(distance_meters) AS avg_distance,
+            ARRAY_AGG(event_id ORDER BY timestamp) AS event_ids
+        FROM sessioned
+        GROUP BY account_id, session_index
+        HAVING COUNT(*) >= 2  -- at least 2 events
+           AND EXTRACT(EPOCH FROM (MAX(timestamp) - MIN(timestamp))) / 60 >= min_dwell_minutes
+    )
+    SELECT 
+        vc.account_id,
+        a.account_name,
+        vc.entry_time,
+        vc.exit_time,
+        ROUND(EXTRACT(EPOCH FROM (vc.exit_time - vc.entry_time)) / 60)::INTEGER AS duration_minutes,
+        ROUND(
+            GREATEST(0.1, LEAST(1.0,
+                -- Higher confidence for more events
+                (vc.event_count::DECIMAL / 10.0) * 0.3 +
+                -- Higher confidence for better accuracy
+                (1.0 - LEAST(1.0, vc.avg_accuracy / 100.0)) * 0.4 +
+                -- Higher confidence for closer proximity relative to geofence radius (with floor)
+                (1.0 - LEAST(1.0, vc.avg_distance / GREATEST(100.0, a.geofence_radius::DECIMAL))) * 0.3
+            )),
+            2
+        ) AS confidence,
+        vc.event_count::INTEGER,
+        ROUND(vc.avg_accuracy, 1) AS avg_accuracy,
+        vc.event_ids AS location_events_ids
+    FROM visit_candidates vc
+    JOIN accounts a ON a.id = vc.account_id
+    ORDER BY vc.entry_time DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+


### PR DESCRIPTION
Implements Phase 1 of the visit tracking improvement plan.\n\n- Update  to:\n  - Use each account's  (+50m buffer) instead of fixed 1000m proximity\n  - Split events into sessions per account using a 60-minute gap threshold\n  - Keep min dwell ≥ 10 minutes and ≥ 2 events per session\n  - Confidence factors consider proximity relative to radius, accuracy, and event count\n\n- Adds  to track roll-out and follow-ups.\n\nValidate:\n- Run detector preview \n- Confirm long all-day visits disappear and multiple shorter visits appear\n- Spot-check a few users/accounts over 7 days\n\nNext (Phase 2): Max-duration cap and radius bounds.\n\nTarget: develop